### PR TITLE
Correcting typo in com_content sql query

### DIFF
--- a/administrator/components/com_content/Helper/ContentHelper.php
+++ b/administrator/components/com_content/Helper/ContentHelper.php
@@ -293,7 +293,7 @@ class ContentHelper extends \JHelperContent
 		$query
 			->select($db->qn('id') . ' AS value, ' . $db->qn('title') . ' AS text')
 			->from($db->qn('#__workflow_transitions'))
-			->where($db->qn('from_status_id') . ' = ' . (int) $state);
+			->where($db->qn('from_state_id') . ' = ' . (int) $state);
 		$db->setQuery($query);
 		$results = $db->loadAssocList();
 


### PR DESCRIPTION
Pull Request for Issue 42 .

### Summary of Changes
Correcting a typo in com_content query. This is related to a point highlighted in Issue 42


### Testing Instructions
Create a workflow and log in to com_content list view


### Expected result

Showing the list of articles created

### Actual result

An error has occurred.
1054 Unknown column 'from_status_id' in 'where clause'

### Documentation Changes Required
No
