### PR TITLE
remove workflow_id field from categories table

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -199,7 +199,6 @@ CREATE TABLE IF NOT EXISTS `#__banner_tracks` (
 CREATE TABLE IF NOT EXISTS `#__categories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `asset_id` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'FK to the #__assets table.',
-  `workflow_id` int(10) unsigned NOT NULL COMMENT 'Fk to the #__workflows',
   `parent_id` int(10) unsigned NOT NULL DEFAULT 0,
   `lft` int(11) NOT NULL DEFAULT 0,
   `rgt` int(11) NOT NULL DEFAULT 0,
@@ -232,8 +231,7 @@ CREATE TABLE IF NOT EXISTS `#__categories` (
   KEY `idx_path` (`path`(100)),
   KEY `idx_left_right` (`lft`,`rgt`),
   KEY `idx_alias` (`alias`(100)),
-  KEY `idx_language` (`language`),
-  KEY `workflow_id` (`workflow_id`)
+  KEY `idx_language` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 --


### PR DESCRIPTION
Pull Request for Issue 49 .

### Summary of Changes
Remove 'workflow_id' field from #__categories table structure


### Testing Instructions
Goto category view and create a new category, you will get  'workflow_id' does not have a default value. After reinstalling with new schema, you won't see that error and category is saving successfully.


### Expected result
Before fixing:  'workflow_id' does not have a default value.


### Actual result
After fixing: saving the category successfully


### Documentation Changes Required
No
