### PR TITLE
re-write _getAssetParentId method to get proper asset entry

### DIFF
--- a/administrator/components/com_workflow/Table/State.php
+++ b/administrator/components/com_workflow/Table/State.php
@@ -139,7 +139,8 @@ class State extends Table
 		$asset = self::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()));
 		$workflow = new WTable\Workflow($this->getDbo());
 		$workflow->load($this->workflow_id);
-		$name = $workflow->extension . '.workflow.'. (int) $workflow->id; $asset->loadByName($name);
+		$name = $workflow->extension . '.workflow.'. (int) $workflow->id;
+		$asset->loadByName($name);
 		$assetId = $asset->id;
 
 		return !empty($assetId) ? $assetId : parent::_getAssetParentId($table, $id);

--- a/administrator/components/com_workflow/Table/Transition.php
+++ b/administrator/components/com_workflow/Table/Transition.php
@@ -82,7 +82,8 @@ class Transition extends Table
 		$asset = self::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()));
 		$workflow = new WTable\Workflow($this->getDbo());
 		$workflow->load($this->workflow_id);
-		$name = $workflow->extension . '.workflow.'. (int) $workflow->id; $asset->loadByName($name);
+		$name = $workflow->extension . '.workflow.'. (int) $workflow->id;
+		$asset->loadByName($name);
 		$assetId = $asset->id;
 
 		return !empty($assetId) ? $assetId : parent::_getAssetParentId($table, $id);

--- a/administrator/components/com_workflow/Table/Workflow.php
+++ b/administrator/components/com_workflow/Table/Workflow.php
@@ -139,9 +139,30 @@ class Workflow extends Table
 	 */
 	protected function _getAssetParentId(Table $table = null, $id = null)
 	{
-		$asset = Table::getInstance("Asset");
-		$asset->loadByName($this->extension . '.workflow.' . $this->id);
+		$assetId = null;
 
-		return (int) $asset->id;
+        // Build the query to get the asset id for the parent category.
+        $query = $this->_db->getQuery(true)
+            ->select($this->_db->quoteName('id'))
+            ->from($this->_db->quoteName('#__assets'))
+            ->where($this->_db->quoteName('name') . ' = ' . $this->_db->quote($this->extension));
+
+        // Get the asset id from the database.
+        $this->_db->setQuery($query);
+
+        if ($result = $this->_db->loadResult())
+        {
+            $assetId = (int) $result;
+        }
+
+        // Return the asset id.
+        if ($assetId)
+        {
+            return $assetId;
+        }
+        else
+        {
+            return parent::_getAssetParentId($table, $id);
+        }
 	}
 }

--- a/administrator/components/com_workflow/Table/Workflow.php
+++ b/administrator/components/com_workflow/Table/Workflow.php
@@ -141,28 +141,28 @@ class Workflow extends Table
 	{
 		$assetId = null;
 
-        // Build the query to get the asset id for the parent category.
-        $query = $this->_db->getQuery(true)
-            ->select($this->_db->quoteName('id'))
-            ->from($this->_db->quoteName('#__assets'))
-            ->where($this->_db->quoteName('name') . ' = ' . $this->_db->quote($this->extension));
+		// Build the query to get the asset id for the parent category.
+		$query = $this->_db->getQuery(true)
+			->select($this->_db->quoteName('id'))
+			->from($this->_db->quoteName('#__assets'))
+			->where($this->_db->quoteName('name') . ' = ' . $this->_db->quote($this->extension));
 
-        // Get the asset id from the database.
-        $this->_db->setQuery($query);
+		// Get the asset id from the database.
+		$this->_db->setQuery($query);
 
-        if ($result = $this->_db->loadResult())
-        {
-            $assetId = (int) $result;
-        }
+		if ($result = $this->_db->loadResult())
+		{
+			$assetId = (int) $result;
+		}
 
-        // Return the asset id.
-        if ($assetId)
-        {
-            return $assetId;
-        }
-        else
-        {
-            return parent::_getAssetParentId($table, $id);
-        }
+		// Return the asset id.
+		if ($assetId)
+		{
+			return $assetId;
+		}
+		else
+		{
+			return parent::_getAssetParentId($table, $id);
+		}
 	}
 }


### PR DESCRIPTION
Pull Request for Issue 52 .

### Summary of Changes

Rewrite Workflow Table class - _getAssetParentId to identify correct parent using $this->extension

### Testing Instructions

Try to save already created workflow

### Expected result

Before fixing, there's an error and saving failed

### Actual result

After fixing: saving properly

### Documentation Changes Required

No