### PR TITLE
Insert State entry in asset table

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -2150,7 +2150,7 @@ CREATE TABLE IF NOT EXISTS `#__workflow_states` (
   PRIMARY KEY (`id`),
   KEY `workflow_id` (`workflow_id`),
   KEY `title` (`title`(191)),
-  KEY `access` (`asset_id`),
+  KEY `asset_id` (`asset_id`),
   KEY `default` (`default`)
 ) ENGINE=InnoDB DEFAULT COLLATE=utf8mb4_unicode_ci;
 


### PR DESCRIPTION
Pull Request for Issue 55 .

### Summary of Changes
Fixing typo in sql script


### Testing Instructions
Create a new workflow-state and check the asset table. 


### Expected result

Before fix: no entry in asset table

### Actual result

After fix: New entry should be there respect to new state

### Documentation Changes Required

No