### PR TITLE
filtering states only which are published/unpublished

### DIFF
--- a/administrator/components/com_workflow/Helper/WorkflowHelper.php
+++ b/administrator/components/com_workflow/Helper/WorkflowHelper.php
@@ -123,7 +123,8 @@ class WorkflowHelper extends ContentHelper
 		$query
 			->select($db->quoteName(['id', 'title'], ['value', $fieldName]))
 			->from($db->quoteName('#__workflow_states'))
-			->where($db->quoteName('workflow_id') . ' = ' . (int) $workflowID);
+			->where($db->quoteName('workflow_id') . ' = ' . (int) $workflowID)
+			->andWhere($db->quoteName('published') . ' IN (0, 1)');
 
 		return (string) $query;
 	}


### PR DESCRIPTION
Pull Request for Issue 60 .
https://github.com/joomla-projects/GSoC17_publishing_workflow/issues/60

### Summary of Changes
Change Transition Edit view to display only the states in published and unpublished


### Testing Instructions
Create a workflow and add some states. Make some states "trashed". 
Go to new transition creation view.
Open From State / To State dropdown


### Expected result
Before Fix : all states are listed (even trashed states)


### Actual result
After Fix : trashed and archive states are no longer in the list


### Documentation Changes Required
No