### PR TITLE
fix for showing side-menu after cancelling from state view

### DIFF
--- a/administrator/components/com_workflow/View/States/Html.php
+++ b/administrator/components/com_workflow/View/States/Html.php
@@ -97,6 +97,8 @@ class Html extends HtmlView
 		WorkflowHelper::callMethodFromHelper($this->state->get("filter.extension"), "addSubmenu", "states");
 		$this->sidebar       = \JHtmlSidebar::render();
 
+		$this->extension = $this->state->get('filter.extension');
+
 		if (!empty($this->states))
 		{
 			foreach ($this->states as $i => $item)

--- a/administrator/components/com_workflow/tmpl/states/default_body.php
+++ b/administrator/components/com_workflow/tmpl/states/default_body.php
@@ -15,7 +15,7 @@ $workflowID = $this->escape($this->state->get('filter.workflow_id'));
 
 ?>
 <?php foreach ($this->states as $i => $item):
-	$link = JRoute::_('index.php?option=com_workflow&task=state.edit&id=' . $item->id . '&workflow_id=' . $workflowID);
+	$link = JRoute::_('index.php?option=com_workflow&task=state.edit&id=' . $item->id . '&workflow_id=' . $workflowID . '&extension=' . $this->extension);
 	?>
 	<tr class="row<?php echo $i % 2; ?>" data-dragable-group="<?php echo $item->id; ?>">
 		<td class="order nowrap text-center hidden-sm-down">


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-projects/GSoC17_publishing_workflow/issues/64 .

### Summary of Changes

Add the extension to the link showing in list of states

### Testing Instructions

Select 'manage' of a workflow. 
Go to edit view of a state, and click cancel.

### Expected result

The left-side menu should be visible after returning

### Actual result

The left-side menu is not visible after returning

### Documentation Changes Required

No