### PR TITLE
Improve transition generic.select list in articles overview

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -168,7 +168,14 @@ $assoc = JLanguageAssociations::isEnabled();
 									<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 								</td>
 								<td class="text-center">
-									<?php echo JHTML::_('select.genericlist', $transitions, 'transition_id[]', 'class="inputbox" size="1" onclick="event.stopPropagation()" onchange="Joomla.uncheckAll(this); Joomla.toggleOne(this, true); Joomla.submitform(\'articles . runTransition\');"', 'value', 'text',  0); ?>
+									<?php			
+									$attribs = [
+										'id'	=> 'transition-select_'. (int) $item->id,
+										'list.attr' => [	
+											'class'		=> 'custom-select', 
+											'onchange'		=> "Joomla.submitform('articles.runTransition')"]
+										];
+									echo JHTML::_('select.genericlist', $transitions, 'transition_id[]', $attribs); ?>
 								</td>
 								<td class="has-context">
 									<div class="break-word">


### PR DESCRIPTION
On articles overview, every article gets a generic select list for transitions. These select lists have all the same id. 
This PR gives every select list an own id.
It gives class "custom-select" and improves the layout.

**Testing instructions**
Make a worflow with several states and transitions, make a category which use this workflow.
Add some articles to this category.
See the Overview - every article has a select list for Transitions.

### Expected result
Open the source in the browser - dropdowns must have unique IDs

### Actual result
All dropdowns have the same ID

Apply the Patch.
IDs are now unique. 
The layout is improved.

### Documentation Changes Required
No

