### PR TITLE
Fix create time sql

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -2161,7 +2161,7 @@ CREATE TABLE IF NOT EXISTS `#__workflows` (
 --
 
 INSERT INTO `#__workflows` (`id`, `asset_id`, `published`, `title`, `description`, `extension`, `default`, `created`, `created_by`, `modified`, `modified_by`) VALUES
-(1, 56, 1, 'Joomla! Default', '', 'com_content', 1, 'NOW()', 0, '0000-00-00 00:00:00', 0);
+(1, 56, 1, 'Joomla! Default', '', 'com_content', 1, NOW(), 0, '0000-00-00 00:00:00', 0);
 
 --
 -- Dumping data for table `#__workflow_states`


### PR DESCRIPTION
Pull Request for Issue #102 .

### Summary of Changes
Remove quotes in sql NOW() function


### Testing Instructions
Do a clean install and check #__workflows table initial entry


### Before
Created time is shown as 00000


### After
Created time is installation time



### Documentation Changes Required
N/A
