### PR TITLE
Use plurals for the sidebar

### DIFF
--- a/administrator/components/com_content/Helper/ContentHelper.php
+++ b/administrator/components/com_content/Helper/ContentHelper.php
@@ -58,13 +58,13 @@ class ContentHelper extends \JHelperContent
 				$workflowID = $app->getUserStateFromRequest('filter.workflow_id', 'workflow_id', 1, 'int');
 
 				\JHtmlSidebar::addEntry(
-					\JText::_('COM_WORKFLOW_STATE'),
+					\JText::_('COM_WORKFLOW_STATES'),
 					'index.php?option=com_workflow&view=states&workflow_id=' . $workflowID . "&extension=com_content",
 					$vName == 'states`'
 				);
 
 				\JHtmlSidebar::addEntry(
-					\JText::_('COM_WORKFLOW_TRANSITION'),
+					\JText::_('COM_WORKFLOW_TRANSITIONS'),
 					'index.php?option=com_workflow&view=transitions&workflow_id=' . $workflowID . "&extension=com_content",
 					$vName == 'transitions'
 				);


### PR DESCRIPTION
### Summary of Changes
Use Plural for links to list views in the sidebar. 

### Testing Instructions
Open a worflow, you get two more Links in the side bar which go to list views. These links shold be plural
Apply the patch, compare,
![sidebar](https://user-images.githubusercontent.com/1035262/30251503-8b04645e-9660-11e7-8293-624533c61259.PNG)

Remark: It is possible to simply change the language file and not the contentHelper. But it would not be consitent.

### Documentation Changes Required
Yes, if there are screenshots

