### PR TITLE
Disable the switcher on edit state if the state is default

### DIFF
--- a/administrator/components/com_workflow/tmpl/state/edit.php
+++ b/administrator/components/com_workflow/tmpl/state/edit.php
@@ -40,8 +40,8 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 					<fieldset class="form-vertical form-no-margin">
 						<?php echo $this->form->renderField('published'); ?>
 						
-						<?php if ($this->form->getValue('default', null, null)): ?>
-							<?php $this->form->setFieldAttribute('default', 'disabled', 'true', null); ?>
+						<?php if ($this->form->getValue('default')): ?>
+							<?php $this->form->setFieldAttribute('default', 'disabled', 'true', ''); ?>
 						<?php endif; ?>
 						<?php echo $this->form->renderField('default'); ?>
 					</fieldset>

--- a/administrator/components/com_workflow/tmpl/state/edit.php
+++ b/administrator/components/com_workflow/tmpl/state/edit.php
@@ -38,22 +38,12 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			<div class="card card-block card-light">
 				<div class="card-body">
 					<fieldset class="form-vertical form-no-margin">
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('published'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('published'); ?>
-							</div>
-						</div>
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('default'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('default'); ?>
-							</div>
-						</div>
+						<?php echo $this->form->renderField('published'); ?>
+						
+						<?php if ($this->form->getValue('default', null, null)): ?>
+							<?php $this->form->setFieldAttribute('default', 'disabled', 'true', null); ?>
+						<?php endif; ?>
+						<?php echo $this->form->renderField('default'); ?>
 					</fieldset>
 				</div>
 			</div>


### PR DESCRIPTION
### Summary of Changes
This PR disables the default switcher on edit state if the state is default. 


### Testing Instructions
Open a state which is default. 
Switch the default-switcher to "no".
Save the state.
You will get an Errormessage - see screen below, and the state is not saved.

Apply the patch and repeat the test.
You cannot switch to default "no". 

### Expected result
Expected is a warning that it is not possible to remove the default state. Because there must be a default state.
But it seems more convenient if the switch is disabled, So there is no need for warning - "don't make me think!".

NOTE: The switcher is disabled but at the moment it does not look disabled because the switcher does not support the disabled attribute. This will be fixed soon. 

### Actual result
![default-switcher](https://user-images.githubusercontent.com/1035262/30253786-54b460c6-968c-11e7-8a3c-8c060c3ca1f2.PNG)


### Documentation Changes Required
No
