### PR TITLE
Adding current state to article edit view, transition drop-down

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -66,7 +66,6 @@
 			addfieldprefix="Joomla\Component\Workflow\Administrator\Field"
 			label="COM_CONTENT_TRANSITION"
 		>
-			<option	value="">COM_CONTENT_SELECT_TRANSITION</option>
 		</field>
 
 		<field 

--- a/administrator/components/com_workflow/Field/TransitionField.php
+++ b/administrator/components/com_workflow/Field/TransitionField.php
@@ -70,9 +70,22 @@ class TransitionField extends \JFormFieldList
 			$items = ArrayHelper::sortObjects($items, 'value', 1, true, true);
 		}
 
-		// Merge any additional options in the XML definition.
-		$options = array_merge(parent::getOptions(), $items);
+		// Get state title
+		$query
+			->clear()
+			->select($db->qn('title', 'text'))
+			->from($db->qn('#__workflow_states'))
+			->where($db->qn('id') . '=' . $state);
 
+		$state = $db->setQuery($query)->loadObject();
+
+		$default = [
+			\JHtml::_('select.option', '', $state->text),
+			\JHtml::_('select.option', '-1', '--------', ['disable' => true])
+		];
+
+		// Merge with defaults
+		$options = array_merge($default, $items);
 		return $options;
 	}
 }


### PR DESCRIPTION
### Summary of Changes
This will add current state in the beginning of the list with a separator, In edit articles view.


### Testing Instructions
Edit and article and open transition list.


### Before

Only the transitions are displayed

### After

Current state is displayed first

### Documentation Changes Required
N/A
