### PR TITLE
Move the main properties auf a transition from the right column to the main panel

### DIFF
--- a/administrator/components/com_workflow/forms/transition.xml
+++ b/administrator/components/com_workflow/forms/transition.xml
@@ -21,18 +21,6 @@
 			size="40"
 			required="true"
 		/>
-
-		<field
-			name="description"
-			type="editor"
-			label="COM_WORKFLOW_FIELD_DESC_LABEL"
-			class="input-xxlarge input-large-text"
-		/>
-
-	</fieldset>
-
-	<fieldset name="params"
-	          label="COM_WORKFLOW_PARAMS_LABEL">
 		<field
 			name="from_state_id"
 			type="sql"
@@ -46,7 +34,17 @@
 			label="COM_WORKFLOW_TO_STATE"
 			required="true"
 		/>
+		<field
+			name="description"
+			type="editor"
+			label="COM_WORKFLOW_FIELD_DESC_LABEL"
+			class="input-xxlarge input-large-text"
+		/>
 
+	</fieldset>
+
+	<fieldset name="params"
+	          label="COM_WORKFLOW_PARAMS_LABEL">
 		<field
 			name="published"
 			type="status"

--- a/administrator/components/com_workflow/tmpl/transition/edit.php
+++ b/administrator/components/com_workflow/tmpl/transition/edit.php
@@ -30,6 +30,22 @@ $tmpl    = $isModal || $this->input->get('tmpl', '', 'cmd') === 'component' ? '&
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_WORKFLOW_DESCRIPTION')); ?>
 		<div class="row">
 			<div class="col-md-9">
+				<div class="control-group">
+					<div class="control-label">
+						<?php echo $this->form->getLabel('from_state_id'); ?>
+					</div>
+					<div class="controls">
+						<?php echo $this->form->getInput('from_state_id'); ?>
+					</div>
+				</div>
+				<div class="control-group">
+					<div class="control-label">
+						<?php echo $this->form->getLabel('to_state_id'); ?>
+					</div>
+					<div class="controls">
+						<?php echo $this->form->getInput('to_state_id'); ?>
+					</div>
+				</div>
 				<?php echo $this->form->getInput('description'); ?>
 			</div>
 			<div class="col-md-3">
@@ -42,22 +58,6 @@ $tmpl    = $isModal || $this->input->get('tmpl', '', 'cmd') === 'component' ? '&
 								</div>
 								<div class="controls">
 									<?php echo $this->form->getInput('published'); ?>
-								</div>
-							</div>
-							<div class="control-group">
-								<div class="control-label">
-									<?php echo $this->form->getLabel('from_state_id'); ?>
-								</div>
-								<div class="controls">
-									<?php echo $this->form->getInput('from_state_id'); ?>
-								</div>
-							</div>
-							<div class="control-group">
-								<div class="control-label">
-									<?php echo $this->form->getLabel('to_state_id'); ?>
-								</div>
-								<div class="controls">
-									<?php echo $this->form->getInput('to_state_id'); ?>
 								</div>
 							</div>
 						</fieldset>


### PR DESCRIPTION
### Summary of Changes
The main data of a transion ist the target state and teh main state. Both are placed in the publisihng area.
This PR moves them on the main panel. 

### Testing Instructions
Open a Transition, the to / from state information is placed in the pubishing area

Apply the patch. To and From state are above the description of the transition

### Documentation Changes Required
yes, if there are screenschots
