### PR TITLE
Implement workflow associations delete when deleting articles

### DIFF
--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -174,9 +174,11 @@ class ArticleModel extends AdminModel
 	{
 		if (!empty($record->id))
 		{
-			$state = new \Joomla\Component\Workflow\Administrator\Table\State($this->_db);
+			$state = new \Joomla\Component\Workflow\Administrator\Table\StateTable($this->_db);
 
-			if (!$state->load($record->state) || $state->condition != -2)
+			$workflowAssociation = WorkflowHelper::getAssociatedEntry((int) $record->id);
+
+			if (!$state->load($workflowAssociation->state_id) || $state->condition != -2)
 			{
 				return false;
 			}
@@ -903,6 +905,9 @@ class ArticleModel extends AdminModel
 				->where('content_id IN (' . implode(',', $pks) . ')');
 			$db->setQuery($query);
 			$db->execute();
+
+			// Remove entry in workflow_association table
+			WorkflowHelper::removeAssociationsByItemIds($pks);
 		}
 
 		return $return;

--- a/administrator/components/com_workflow/Helper/WorkflowHelper.php
+++ b/administrator/components/com_workflow/Helper/WorkflowHelper.php
@@ -231,7 +231,7 @@ class WorkflowHelper extends ContentHelper
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public static function removeAssociationByItemId($itemId, $extension = 'com_content')
+	public static function removeAssociationsByItemIds($pks, $extension = 'com_content')
 	{
 		try
 		{
@@ -240,7 +240,7 @@ class WorkflowHelper extends ContentHelper
 
 			$query
 				->delete($db->qn('#__workflow_associations'))
-				->where($db->qn('item_id') . '=' . (int) $itemId)
+				->where($db->qn('item_id') . 'IN (' . implode(',', $pks) . ')')
 				->andWhere($db->qn('extension') . '=' . $db->quote($extension));
 
 			$db->setQuery($query);


### PR DESCRIPTION
Pull Request for Issue #141  .

### Summary of Changes

This will delete the workflow_associations entry when deleting articles permanently 

### Testing Instructions

Delete an article in Trashed state

### Expected result

#__workflow_association related entries should get removed


